### PR TITLE
Recognize long-named atoms.

### DIFF
--- a/PS.g4
+++ b/PS.g4
@@ -104,7 +104,7 @@ DIFFERENTIAL: 'd' WS_CHAR*? ([a-zA-Z] | '\\' [a-zA-Z]+);
 
 FUNC_EXP: 'e';
 LETTER: [a-df-zA-Z];//exclude e for exp
-LONGNAME: ([A-Z][A-Z]+ | [a-z][a-z]+);
+LONGNAME: ([A-Z][A-Za-z]+ | [a-z][a-z]+);
 fragment DIGIT: [0-9];
 NUMBER:
     DIGIT+ (',' DIGIT DIGIT DIGIT)*

--- a/PS.g4
+++ b/PS.g4
@@ -104,7 +104,7 @@ DIFFERENTIAL: 'd' WS_CHAR*? ([a-zA-Z] | '\\' [a-zA-Z]+);
 
 FUNC_EXP: 'e';
 LETTER: [a-df-zA-Z];//exclude e for exp
-LONGNAME: [A-Z][A-Z]+;
+LONGNAME: ([A-Z][A-Z]+ | [a-z][a-z]+);
 fragment DIGIT: [0-9];
 NUMBER:
     DIGIT+ (',' DIGIT DIGIT DIGIT)*

--- a/PS.g4
+++ b/PS.g4
@@ -104,6 +104,7 @@ DIFFERENTIAL: 'd' WS_CHAR*? ([a-zA-Z] | '\\' [a-zA-Z]+);
 
 FUNC_EXP: 'e';
 LETTER: [a-df-zA-Z];//exclude e for exp
+LONGNAME: [A-Z][A-Z]+;
 fragment DIGIT: [0-9];
 NUMBER:
     DIGIT+ (',' DIGIT DIGIT DIGIT)*
@@ -241,7 +242,7 @@ accent:
     accent_symbol
     L_BRACE base=expr R_BRACE;
 
-atom: (LETTER | SYMBOL | accent) subexpr? | NUMBER | DIFFERENTIAL | mathit | PLACEHOLDER;
+atom: (LETTER | LONGNAME | SYMBOL | accent) subexpr? | NUMBER | DIFFERENTIAL | mathit | PLACEHOLDER;
 
 mathit: CMD_MATHIT L_BRACE mathit_text R_BRACE;
 mathit_text: (LETTER | FUNC_EXP)+;

--- a/process_latex.py
+++ b/process_latex.py
@@ -321,9 +321,9 @@ def convert_comp(comp):
         return convert_func(comp.func())
 
 def convert_atom(atom):
-    if atom.LETTER():
+    if atom.LETTER() or atom.LONGNAME():
         subscriptName = ''
-        s = atom.LETTER().getText()
+        s = atom.LETTER().getText() if atom.LETTER() else atom.LONGNAME().getText()
         if s == "I":
             return sympy.I
         if atom.subexpr():
@@ -333,7 +333,7 @@ def convert_atom(atom):
             else:                               # subscript is atom
                 subscript = convert_atom(atom.subexpr().atom())
             subscriptName = '_{' + StrPrinter().doprint(subscript) + '}'
-        return sympy.Symbol(atom.LETTER().getText() + subscriptName, real=True)
+        return sympy.Symbol(s + subscriptName, real=True)
     elif atom.SYMBOL():
         s = atom.SYMBOL().getText()[1:]
         if s == "infty":


### PR DESCRIPTION
Certain LaTeX equations feature variable names comprising two or more characters. The current parser expects single-character names, such as 'X' or 'Y'. When given a name such as 'ABC', the parser breaks it into three distinct atoms and assumes an implicit multiplication operation between them.

This commit lets the parser recognize all-capital words with two or more characters as atoms so that the example above gets translated into a single atom.

The following snippet taken from [Wikipedia](https://en.wikipedia.org/wiki/Wind_chill) inspired this fix. Note that WCI is now properly recognized as a single atom:
```
{WCI=\left(10{\sqrt {v}}-v+10.5\right)\cdot \left(33-T_{\mathrm {a} }\right)}
```
